### PR TITLE
Focus on selected building

### DIFF
--- a/gui/session/selection_panels_helpers~autociv.js
+++ b/gui/session/selection_panels_helpers~autociv.js
@@ -1,0 +1,10 @@
+function setCameraFollow(entity)
+{
+	let entState = entity && GetEntityState(entity);
+	if (entState && hasClass(entState, "Unit"))
+		Engine.CameraFollow(entity);
+	else if (!entState || !entState.position)
+		Engine.CameraFollow(0);
+	else
+		Engine.CameraMoveTo(entState.position.x, entState.position.z);
+}


### PR DESCRIPTION
I needed a way to focus on a selected building by pressing the "F" hotkey.

Right now "F" only follows a unit, and is completely ignored when a building is selected.