### PR TITLE
Coloring the name of the observer

### DIFF
--- a/gui/session/objectives/autociv_playersOverlay.js
+++ b/gui/session/objectives/autociv_playersOverlay.js
@@ -52,7 +52,8 @@ AutocivControls.PlayersOverlay = class
 
         const caption = list.map(([name, isPlayer]) =>
         {
-            return isPlayer ? setStringTags(name, { "color": this.playerOfflineColor, }) : name
+            const color = PlayerColor.GetPlayerColor(splitRatingFromNick(name).nick);
+            return isPlayer ? setStringTags(name, { "color": this.playerOfflineColor, }) : setStringTags(name, { color });
         }).join(", ")
 
         this.autociv_playersOverlay.hidden = !caption

--- a/gui/session/objectives/autociv_playersOverlay.js
+++ b/gui/session/objectives/autociv_playersOverlay.js
@@ -53,7 +53,7 @@ AutocivControls.PlayersOverlay = class
         const caption = list.map(([name, isPlayer]) =>
         {
             const color = PlayerColor.GetPlayerColor(splitRatingFromNick(name).nick);
-            return isPlayer ? setStringTags(name, { "color": this.playerOfflineColor, }) : setStringTags(name, { color });
+            return isPlayer ? setStringTags(name, { "color": this.playerOfflineColor, }) : g_IsNetworked ? setStringTags(name, { color }) : name;
         }).join(", ")
 
         this.autociv_playersOverlay.hidden = !caption

--- a/gui/session/objectives/autociv_playersOverlay.xml
+++ b/gui/session/objectives/autociv_playersOverlay.xml
@@ -1,6 +1,12 @@
-<object name="autociv_playersOverlay"
+<object>
+    <script file="gui/lobby/LobbyPage/PlayerColor.js"/>
+
+    <object name="autociv_playersOverlay"
     size="100%-400 100%-228-100 100% 100%-100"
     sprite="color:0 0 0 150"
     hidden="true"
     ghost="true"
-    type="text"/>
+    type="text">
+    </object>
+
+</object>


### PR DESCRIPTION

Colored observer names are easier and faster to read.
<img src="https://raw.githubusercontent.com/LangLangBart/ImagePool/5ed35096b3ddba8b07afc3d801821666b1977ee7/storage/10_Oct_22_at_23_41_32_autociv_color_observer.png" width="800">

Idea *borrowed* from @Mentula (forum post: [Cheers and... WELCOME TO ALPHA 26!](https://wildfiregames.com/forum/topic/80151-localratings-mod-evaluate-players-skills-based-on-previous-games/page/3/#comment-522206))
