### PR TITLE
feat: add a function to brighten colors

### DIFF
--- a/gui/common/functions_utility~autociv.js
+++ b/gui/common/functions_utility~autociv.js
@@ -92,3 +92,16 @@ autoCompleteText.state = {
     "oldCaption": "",
     "tries": 0
 }
+
+/**
+ * See gui/lobby/LobbyPage/PlayerColor.GetPlayerColor function for explanation
+ * Some colors must become brighter so that they are readable on dark backgrounds.
+ * @param   {string}  color  string of rgb color, e.g. "10 10 190" ("Dark Blue")
+ * @return  {string}         string of brighter rgb color, e.g. "61 61 245" ("Blue")
+ */
+function brightenedColor(color)
+{
+	const [r, g, b] = color.split(" ").map(x => +x);
+	const [h, s, l] = rgbToHsl(r, g, b);
+	return hslToRgb(h, s, Math.max(0.65, l)).join(" ");
+}

--- a/gui/session/objectives/autociv_statsOverlay.js
+++ b/gui/session/objectives/autociv_statsOverlay.js
@@ -93,9 +93,9 @@ AutocivControls.StatsOverlay = class
         return index
     }
 
-    playerColor(state)
+    brightenedPlayerColor(state)
     {
-        return rgbToGuiColor(g_DiplomacyColors.displayedPlayerColors[state.playerNumber])
+        return brightenedColor(rgbToGuiColor(g_DiplomacyColors.displayedPlayerColors[state.playerNumber]))
     }
 
     leftPadTrunc(text, size)
@@ -175,7 +175,7 @@ AutocivControls.StatsOverlay = class
             if (state.state == "defeated")
                 return setStringTags(preStats + stats, { "color": "255 255 255 128" })
 
-            return setStringTags(preStats, { "color": this.playerColor(state) }) + stats
+            return setStringTags(preStats, { "color": this.brightenedPlayerColor(state) }) + stats
 
         }).join("\n")
 


### PR DESCRIPTION
### Idea
- Some colors must become brighter so that they are readable on dark backgrounds.

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/dc8d75b808f0f9f12da3df0e65b732267532fe4d/storage/2023-03-10_23-47-05_bright_color.png" width="600">
