### PR TITLE
perceivedBrightness

### DIFF
--- a/gui/common/functions_utility~autociv.js
+++ b/gui/common/functions_utility~autociv.js
@@ -94,14 +94,20 @@ autoCompleteText.state = {
 }
 
 /**
- * See gui/lobby/LobbyPage/PlayerColor.GetPlayerColor function for explanation
  * Some colors must become brighter so that they are readable on dark backgrounds.
+ * Modified version from gui/lobby/LobbyPage/PlayerColor.GetPlayerColor function
+ * Additional check for "perceivedBrightness", if the color is already bright enough don't change it
+ * https://www.w3.org/TR/AERT/#color-contrast
  * @param   {string}  color  string of rgb color, e.g. "10 10 190" ("Dark Blue")
- * @return  {string}         string of brighter rgb color, e.g. "61 61 245" ("Blue")
+ * @return  {string}         string of brighter rgb color, e.g. "57 57 245" ("Blue")
  */
 function brightenedColor(color)
 {
-	const [r, g, b] = color.split(" ").map(x => +x);
-	const [h, s, l] = rgbToHsl(r, g, b);
-	return hslToRgb(h, s, Math.max(0.65, l)).join(" ");
+    const [r, g, b] = color.split(" ").map(x => +x);
+    const perceivedBrightness = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+    if (perceivedBrightness > 80)
+        return color;
+    const [h, s, l] = rgbToHsl(r, g, b);
+    return hslToRgb(h, s, Math.min(l + 0.2, 0.6)).join(" ");
+
 }

--- a/gui/common/functions_utility~autociv.js
+++ b/gui/common/functions_utility~autociv.js
@@ -92,3 +92,16 @@ autoCompleteText.state = {
     "oldCaption": "",
     "tries": 0
 }
+
+/**
+ * See gui/lobby/LobbyPage/PlayerColor.GetPlayerColor function for explanation
+ * Some colors must become brighter so that they are readable on dark backgrounds.
+ * @param   {string}  color  string of rgb color, e.g. "10 10 190" ("Dark Blue")
+ * @return  {string}         string of brighter rgb color, e.g. "61 61 245" ("Blue")
+ */
+function brightenedColor(color)
+{
+	const [r, g, b] = color.split(" ").map(x => +x);
+	const [h, s, l] = rgbToHsl(r, g, b);
+	return hslToRgb(h, s, Math.max(0.65, l)).join(" ");
+}

--- a/gui/common/functions_utility~autociv.js
+++ b/gui/common/functions_utility~autociv.js
@@ -103,7 +103,7 @@ const autociv_ColorsSeenBefore = {};
  * https://www.w3.org/TR/AERT/#color-contrast
  * Additional check for "standardDeviation", because gray colors have the "perceivedBrightness" but are not colorful enough.
  * @param   {string}  color  string of rgb color, e.g. "10 10 190" ("Dark Blue")
- * @return  {string}         string of brighter rgb color, e.g. "57 57 245" ("Blue")
+ * @return  {string}         string of brighter rgb color, e.g. "61 61 245" ("Blue")
  */
 function brightenedColor(color)
 {

--- a/gui/session/objectives/autociv_statsOverlay.js
+++ b/gui/session/objectives/autociv_statsOverlay.js
@@ -93,7 +93,7 @@ AutocivControls.StatsOverlay = class
         return index
     }
 
-    brightenedPlayerColor(state)
+    playerColor(state)
     {
         return brightenedColor(rgbToGuiColor(g_DiplomacyColors.displayedPlayerColors[state.playerNumber]))
     }
@@ -175,7 +175,7 @@ AutocivControls.StatsOverlay = class
             if (state.state == "defeated")
                 return setStringTags(preStats + stats, { "color": "255 255 255 128" })
 
-            return setStringTags(preStats, { "color": this.brightenedPlayerColor(state) }) + stats
+            return setStringTags(preStats, { "color": this.playerColor(state) }) + stats
 
         }).join("\n")
 

--- a/gui/session/objectives/autociv_statsOverlay.js
+++ b/gui/session/objectives/autociv_statsOverlay.js
@@ -93,9 +93,9 @@ AutocivControls.StatsOverlay = class
         return index
     }
 
-    playerColor(state)
+    brightenedPlayerColor(state)
     {
-        return rgbToGuiColor(g_DiplomacyColors.displayedPlayerColors[state.playerNumber])
+        return brightenedColor(rgbToGuiColor(g_DiplomacyColors.displayedPlayerColors[state.playerNumber]))
     }
 
     leftPadTrunc(text, size)
@@ -175,7 +175,7 @@ AutocivControls.StatsOverlay = class
             if (state.state == "defeated")
                 return setStringTags(preStats + stats, { "color": "255 255 255 128" })
 
-            return setStringTags(preStats, { "color": this.playerColor(state) }) + stats
+            return setStringTags(preStats, { "color": this.brightenedPlayerColor(state) }) + stats
 
         }).join("\n")
 


### PR DESCRIPTION
### issue
- Some colors must become brighter so that they are readable on dark backgrounds.

### path to glory
<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/36162366da56efef9d4f908d408a6fa265e50abf/storage/2023-03-11_10-14-44_perceivedBrightness.png" width="600">

```js
// colors for testing extracted from gamesettings/attributes/PlayerColor.js and
// the scenarios folder
const color = [
	{ r: 10, g: 10, b: 190 },
	{ r: 230, g: 10, b: 10 },
	{ r: 125, g: 235, b: 15 },
	{ r: 255, g: 255, b: 55 },
	{ r: 130, g: 0, b: 230 },
	{ r: 255, g: 130, b: 0 },
	{ r: 10, g: 230, b: 230 },
	{ r: 20, g: 80, b: 60 },
	{ r: 220, g: 160, b: 220 },
	{ r: 80, g: 255, b: 190 },
	{ r: 50, g: 150, b: 255 },
	{ r: 100, g: 150, b: 30 },
	{ r: 100, g: 60, b: 30 },
	{ r: 128, g: 0, b: 64 },
	{ r: 255, g: 200, b: 140 },
	{ r: 80, g: 80, b: 80 },
	{ r: 176, g: 0, b: 0 },
	{ r: 255, g: 128, b: 0 },
	{ r: 255, g: 255, b: 0 },
	{ r: 0, g: 128, b: 128 },
	{ r: 99, g: 40, b: 147 },
	{ r: 150, g: 20, b: 20 },
	{ r: 46, g: 46, b: 200 },
	{ r: 160, g: 80, b: 200 },
	{ r: 80, g: 80, b: 200 },
	{ r: 0, g: 255, b: 255 },
	{ r: 131, g: 39, b: 39 },
	{ r: 50, g: 165, b: 5 },
	{ r: 255, g: 128, b: 64 },
	{ r: 64, g: 64, b: 64 },
	{ r: 230, g: 230, b: 75 },
];
```

- colors appear generally more readable while retaining their original hue
<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/52a178995517c43c2a11dc403129adc0ea260a19/storage/2023-03-11_10-15-07_perceivedBrightness_more.png" width="600">

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/ea0401beb1a41d209bd7c4e240312f26e63f27c3/storage/2023-03-11_10-25-51_perceivedBrightness_more2.png" width="600">

- difference to #15
 - Additional check for "perceivedBrightness", if the color is already bright enough don't change it
  - https://www.w3.org/TR/AERT/#color-contrast
