### PR TITLE
feat: use a horizontal ellipsis to truncate player name

### DIFF
--- a/gui/common/functions_utility~autociv.js
+++ b/gui/common/functions_utility~autociv.js
@@ -124,3 +124,21 @@ function brightenedColor(color, brightnessThreshold = 110)
     }
     return autociv_ColorsSeenBefore[key];
 }
+
+const autociv_NameSeenBefore = {};
+
+/**
+ * Truncates a string if it is longer than the specified maximum string length.
+ * @param   {string}  str  [str description]
+ * @param   {number}  num  [num description]
+ * @return  {string}       Truncated string with a horizontal ellipsis
+ */
+function truncateString(str, num)
+{
+    if (!autociv_NameSeenBefore[str])
+    {
+        let nick = splitRatingFromNick(str).nick
+        autociv_NameSeenBefore[str] = nick.length <= num ? nick : nick.slice(0, num) + "…"
+    }
+    return autociv_NameSeenBefore[str]
+}

--- a/gui/common/functions_utility~autociv.js
+++ b/gui/common/functions_utility~autociv.js
@@ -124,21 +124,3 @@ function brightenedColor(color, brightnessThreshold = 110)
     }
     return autociv_ColorsSeenBefore[key];
 }
-
-const autociv_NameSeenBefore = {};
-
-/**
- * Truncates a string if it is longer than the specified maximum string length.
- * @param   {string}  str  [str description]
- * @param   {number}  num  [num description]
- * @return  {string}       Truncated string with a horizontal ellipsis
- */
-function truncateString(str, num)
-{
-    if (!autociv_NameSeenBefore[str])
-    {
-        let {nick} = splitRatingFromNick(str)
-        autociv_NameSeenBefore[str] = nick.length > num ? nick.slice(0, num-1) + "…" : nick;
-    }
-    return autociv_NameSeenBefore[str]
-}

--- a/gui/common/functions_utility~autociv.js
+++ b/gui/common/functions_utility~autociv.js
@@ -137,8 +137,8 @@ function truncateString(str, num)
 {
     if (!autociv_NameSeenBefore[str])
     {
-        let nick = splitRatingFromNick(str).nick
-        autociv_NameSeenBefore[str] = nick.length <= num ? nick : nick.slice(0, num) + "…"
+        let {nick} = splitRatingFromNick(str)
+        autociv_NameSeenBefore[str] = nick.length > num ? nick.slice(0, num-1) + "…" : nick;
     }
     return autociv_NameSeenBefore[str]
 }

--- a/gui/session/objectives/autociv_statsOverlay.js
+++ b/gui/session/objectives/autociv_statsOverlay.js
@@ -112,7 +112,7 @@ AutocivControls.StatsOverlay = class
         let key = `${text} ${num}`
         if (!this.autociv_preStatsSeenBefore[key])
         {
-            let str = splitRatingFromNick(text).nick
+            let str = num > 2 ? splitRatingFromNick(text).nick : text
             this.autociv_preStatsSeenBefore[key] = str.slice(0, num - 1).padEnd(num);
         }
         return this.autociv_preStatsSeenBefore[key]

--- a/gui/session/objectives/autociv_statsOverlay.js
+++ b/gui/session/objectives/autociv_statsOverlay.js
@@ -3,7 +3,7 @@ AutocivControls.StatsOverlay = class
 {
     autociv_statsOverlay = Engine.GetGUIObjectByName("autociv_statsOverlay")
     preStats = {
-        "     Player": state => truncateString(state.name,Object.keys(this.widths)[0].length-1), // Player name
+        "     Player": state => truncateString(state.name,Object.keys(this.widths)[0].length), // Player name
         " ■": state => "■", // Player color
         " #": state => `${state.playerNumber}`, // Player number
         " T": state => state.team != -1 ? `${state.team + 1}` : "", // Team number

--- a/gui/session/objectives/autociv_statsOverlay.js
+++ b/gui/session/objectives/autociv_statsOverlay.js
@@ -3,7 +3,7 @@ AutocivControls.StatsOverlay = class
 {
     autociv_statsOverlay = Engine.GetGUIObjectByName("autociv_statsOverlay")
     preStats = {
-        "     Player": state => state.name, // Player name
+        "     Player": state => truncateString(state.name,Object.keys(this.widths)[0].length-1), // Player name
         " ■": state => "■", // Player color
         " #": state => `${state.playerNumber}`, // Player number
         " T": state => state.team != -1 ? `${state.team + 1}` : "", // Team number

--- a/gui/session/objectives/autociv_statsOverlay.js
+++ b/gui/session/objectives/autociv_statsOverlay.js
@@ -3,13 +3,13 @@ AutocivControls.StatsOverlay = class
 {
     autociv_statsOverlay = Engine.GetGUIObjectByName("autociv_statsOverlay")
     preStats = {
-        "     Player": state => truncateString(state.name,Object.keys(this.widths)[0].length), // Player name
-        " ■": state => "■", // Player color
-        " #": state => `${state.playerNumber}`, // Player number
-        " T": state => state.team != -1 ? `${state.team + 1}` : "", // Team number
+        "Player      ": state => state.name, // Player name
+        "■ ": state => "■", // Player color
+        "# ": state => `${state.playerNumber}`, // Player number
+        "T ": state => state.team != -1 ? `${state.team + 1}` : "", // Team number
     }
     stats = {
-        " P": state => state.phase,
+        "P": state => state.phase,
         " Pop": state => state.popCount,
         " Sup": state => state.classCounts_Support,
         " Inf": state => state.classCounts_Infantry,
@@ -107,6 +107,17 @@ AutocivControls.StatsOverlay = class
         return text.substring(0, size).padStart(size)
     }
 
+    rightPadTruncPreStats(text, num)
+    {
+        let key = `${text} ${num}`
+        if (!this.autociv_preStatsSeenBefore[key])
+        {
+            let str = splitRatingFromNick(text).nick
+            this.autociv_preStatsSeenBefore[key] = str.slice(0, num - 1).padEnd(num);
+        }
+        return this.autociv_preStatsSeenBefore[key]
+    }
+
     calcWidth(rowLength)
     {
         return Engine.GetTextWidth(this.textFont, " ") * rowLength + this.autociv_statsOverlay.buffer_zone * 2
@@ -162,7 +173,7 @@ AutocivControls.StatsOverlay = class
         const entries = playerStates.map((state, index) =>
         {
             const preStats = Object.keys(this.preStats).
-                map(row => this.leftPadTrunc(this.preStats[row](state), this.widths[row])).
+                map(row => this.rightPadTruncPreStats(this.preStats[row](state), this.widths[row])).
                 join("")
 
             const stats = Object.keys(values).map(stat =>
@@ -192,3 +203,6 @@ AutocivControls.StatsOverlay = class
         Engine.ProfileStop()
     }
 }
+
+// Use JS cache for preStats
+AutocivControls.StatsOverlay.prototype.autociv_preStatsSeenBefore = {}


### PR DESCRIPTION
### Description
- it might look better to cut off the player name if it is longer than the given length and add a horizontal ellipsis
 - since the rating is usually not seen anyway, i thought we could just remove it
 - see picture for more clarity

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/68ac56c6e4867b0613d90949836050b702720da7/storage/2023-03-12_23-32-42_horizontal_ellipsis_update.png" width="800">
