### PR TITLE
feat: allow the user to define the brightness threshold in the stats overlay

### DIFF
--- a/autociv_data/default_config.json
+++ b/autociv_data/default_config.json
@@ -16,6 +16,7 @@
 	"autociv.session.chatText.font.change": "false",
 	"autociv.session.chatText.font": "sans-bold-stroke-14",
 	"autociv.session.statsOverlay.visible": "true",
+	"autociv.session.statsOverlay.brightnessThreshold": 110,
 	"autociv.session.playersOverlay.visible": "true",
 	"autociv.session.setHealersInitialStanceAggressive": "false",
 	"hotkey.autociv.open.test": "Ctrl+A+T",

--- a/autociv_data/options.json
+++ b/autociv_data/options.json
@@ -55,6 +55,15 @@
 				"config": "autociv.session.statsOverlay.visible"
 			},
 			{
+				"type": "slider",
+				"label": "[color=\"220 185 70\"]Game:[/color] Brightness of player names",
+				"tooltip": "Adjust the brightness intensity for the player names.",
+				"config": "autociv.session.statsOverlay.brightnessThreshold",
+				"dependencies": ["autociv.session.statsOverlay.visible"],
+				"min": 50,
+				"max": 150
+			},
+			{
 				"type": "boolean",
 				"label": "[color=\"220 185 70\"]Game:[/color] players overlay visible",
 				"tooltip": "Show observers and offline players in an overlay",

--- a/gui/common/functions_utility~autociv.js
+++ b/gui/common/functions_utility~autociv.js
@@ -102,17 +102,20 @@ const autociv_ColorsSeenBefore = {};
  * Additional check for "perceived brightness", if the color is already bright enough don't change it,
  * otherwise go up in small incremental steps till it is bright enough.
  * https://www.w3.org/TR/AERT/#color-contrast
- * @param   {string}  color  				string of rgb color, e.g. "10 10 190" ("Dark Blue")
- * @param   {number}  brightnessThreshold 	Value when a color is considered bright enough; Range:0-255
- * @return  {string}        				string of brighter rgb color, e.g. "100 100 248" ("Blue")
+ * @param   {string}  color                 string of rgb color, e.g. "10 10 190" ("Dark Blue")
+ * @param   {number}  brightnessThreshold   Value when a color is considered bright enough; Range:0-255
+ * @return  {string}                        string of brighter rgb color, e.g. "100 100 248" ("Blue")
 */
-function brightenedColor(color, brightnessThreshold = 100) {
+function brightenedColor(color, brightnessThreshold = 110)
+{
     // check if a cached version is already available
     let key = `${color} ${brightnessThreshold}`
-    if (!autociv_ColorsSeenBefore[key]) {
+    if (!autociv_ColorsSeenBefore[key])
+    {
         let [r, g, b] = color.split(" ").map(x => +x);
         let i = 0;
-        while (r * 0.299 + g * 0.587 + b * 0.114 <= +brightnessThreshold) {
+        while (r * 0.299 + g * 0.587 + b * 0.114 <= +brightnessThreshold)
+        {
             i += 0.001;
             const [h, s, l] = rgbToHsl(r, g, b);
             [r, g, b] = hslToRgb(h, s, l + i);

--- a/gui/session/objectives/autociv_statsOverlay.js
+++ b/gui/session/objectives/autociv_statsOverlay.js
@@ -27,10 +27,12 @@ AutocivControls.StatsOverlay = class
     tickPeriod = 10
     textFont = "mono-stroke-10"
     configKey_visible = "autociv.session.statsOverlay.visible"
+    configKey_brightnessThreshold = "autociv.session.statsOverlay.brightnessThreshold"
 
     constructor()
     {
         this.autociv_statsOverlay.hidden = Engine.ConfigDB_GetValue("user", this.configKey_visible) == "false"
+        this.autociv_brightnessThreshold = Engine.ConfigDB_GetValue("user", this.configKey_brightnessThreshold);
 
         for (let name in this.preStats)
             this.widths[name] = name.length
@@ -47,6 +49,8 @@ AutocivControls.StatsOverlay = class
     {
         if (changes.has(this.configKey_visible))
             this.autociv_statsOverlay.hidden = Engine.ConfigDB_GetValue("user", this.configKey_visible) == "false"
+        if (changes.has(this.configKey_brightnessThreshold))
+            this.autociv_brightnessThreshold = Engine.ConfigDB_GetValue("user", this.configKey_brightnessThreshold)
     }
 
     toggle()
@@ -95,7 +99,7 @@ AutocivControls.StatsOverlay = class
 
     playerColor(state)
     {
-        return brightenedColor(rgbToGuiColor(g_DiplomacyColors.displayedPlayerColors[state.playerNumber]))
+        return brightenedColor(rgbToGuiColor(g_DiplomacyColors.displayedPlayerColors[state.playerNumber]), this.autociv_brightnessThreshold)
     }
 
     leftPadTrunc(text, size)


### PR DESCRIPTION
### Description
- follow up to #16
- allow the user to change the brightness through the options

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/c3a8bafb3d70e91ac8d58dc8dcadf32a16eb957b/storage/2023-03-13_00-49-29_color.png" width="600">
