### PR TITLE
fix: Don't color max/min values of defeated players

### DIFF
--- a/gui/session/objectives/autociv_statsOverlay.js
+++ b/gui/session/objectives/autociv_statsOverlay.js
@@ -73,27 +73,38 @@ AutocivControls.StatsOverlay = class
             this.update()
     }
 
-    maxIndex(list)
+    indexDefeated(state)
+    {
+        let indexListDefeated = []
+        for (let i = 0; i < state.length; i++)
+            if (state[i].state === "defeated")
+                indexListDefeated.push(i)
+        return indexListDefeated
+    }
+
+    maxIndex(list, indexListDefeated)
     {
         let index = 0
         let value = list[index]
-        for (let i = 1; i < list.length; i++) if (list[i] > value)
-        {
-            value = list[i]
-            index = i
-        }
+        for (let i = 1; i < list.length; i++)
+            if (list[i] > value && !indexListDefeated.includes(i))
+            {
+                value = list[i]
+                index = i
+            }
         return index
     }
 
-    minIndex(list)
+    minIndex(list, indexListDefeated)
     {
         let index = 0
         let value = list[index]
-        for (let i = 1; i < list.length; i++) if (list[i] < value)
-        {
-            value = list[i]
-            index = i
-        }
+        for (let i = 1; i < list.length; i++)
+            if (list[i] < value && !indexListDefeated.includes(i))
+            {
+                value = list[i]
+                index = i
+            }
         return index
     }
 
@@ -173,10 +184,11 @@ AutocivControls.StatsOverlay = class
         for (let stat of Object.keys(this.stats))
         {
             let list = playerStates.map(this.stats[stat])
+            let indexListDefeated = this.indexDefeated(playerStates)
             values[stat] = {
                 "list": list,
-                "min": this.minIndex(list),
-                "max": this.maxIndex(list),
+                "min": this.minIndex(list, indexListDefeated),
+                "max": this.maxIndex(list, indexListDefeated),
             }
         }
 


### PR DESCRIPTION
### Description

- Max/Min values of players who have died are still colored instead of being grayed out.
  - For some reason, the color of the first `setStringTags` function overwrites the color of the second `setStringTags` function.
  - The idea of the patch is to collect a list of indices for defeated players, and to disregard the min/max values for these indices.


<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/badb692261472dc0d37d833dfb3e4aa968b71264/storage/2023-03-23_19-15-16_max_min.png" width="600">
---

#### notes
- Higher-order Functions were slower than the `for` loop when the time was measured with `Engine.GetMicroseconds()`.
```js
    indexDefeated(state)
    {
        return state.reduce((arr, value, index) => (value.state === "defeated" ? [...arr, index] : arr), []);
    }

    maxIndex(list, indexListDefeated)
    {
        if (indexListDefeated.length)
            return list.map((value, index) => indexListDefeated.includes(index) ? -Infinity : value).findIndex((ele, _, arr) => ele === Math.max(...arr))
        return list.indexOf(Math.max(...list))
    }

    minIndex(list, indexListDefeated)
    {
        if (indexListDefeated.length)
            return list.map((value, index) => indexListDefeated.includes(index) ? Infinity : value).findIndex((ele, _, arr) => ele === Math.min(...arr))
        return list.indexOf(Math.min(...list))
    }
```
