### PR TITLE
More counters

### DIFF
--- a/gui/options/options.json
+++ b/gui/options/options.json
@@ -1,0 +1,917 @@
+[
+	{
+		"label": "General",
+		"tooltip": "Change general options.",
+		"options":
+		[
+			{
+				"type": "string",
+				"label": "Player name (single-player)",
+				"tooltip": "How you want to be addressed in single-player matches.",
+				"config": "playername.singleplayer"
+			},
+			{
+				"type": "string",
+				"label": "Player name (multiplayer)",
+				"tooltip": "How you want to be addressed in multiplayer matches (except lobby).",
+				"config": "playername.multiplayer"
+			},
+			{
+				"type": "boolean",
+				"label": "Background pause",
+				"tooltip": "Pause single-player games when window loses focus.",
+				"config": "pauseonfocusloss",
+				"function": "PauseOnFocusLoss"
+			},
+			{
+				"type": "boolean",
+				"label": "Enable welcome screen",
+				"tooltip": "If you disable it, the welcome screen will still appear, each time a new version is available. You can always launch it from the main menu.",
+				"config": "gui.splashscreen.enable"
+			}
+		]
+	},
+	{
+		"label": "Graphics (general)",
+		"tooltip": "Set the balance between performance and visual appearance.",
+		"options":
+		[
+			{
+				"type": "boolean",
+				"label": "Windowed mode",
+				"tooltip": "Start 0 A.D. in a window.",
+				"config": "windowed"
+			},
+			{
+				"type": "boolean",
+				"label": "Fog",
+				"tooltip": "Enable fog.",
+				"config": "fog"
+			},
+			{
+				"type": "boolean",
+				"label": "Post-processing",
+				"tooltip": "Use screen-space post-processing filters (HDR, Bloom, DOF, etc).",
+				"config": "postproc"
+			},
+			{
+				"type": "dropdownNumber",
+				"label": "Resolution scale",
+				"tooltip": "A smaller scale makes rendering faster but produces a more blurry picture, a large scale makes rendering slower but produces a better picture.",
+				"dependencies": ["postproc"],
+				"config": "renderer.scale",
+				"list": [
+					{ "value": 0.5, "label": "50%" },
+					{ "value": 0.75, "label": "75%" },
+					{ "value": 0.875, "label": "87.5%" },
+					{ "value": 1.00, "label": "100%" },
+					{ "value": 1.25, "label": "125%" },
+					{ "value": 1.50, "label": "150%" },
+					{ "value": 1.75, "label": "175%" },
+					{ "value": 2.00, "label": "200%" }
+				]
+			},
+			{
+				"type": "dropdown",
+				"label": "Upscale technique",
+				"tooltip": "Technique defines performance and quality of upscaling process.",
+				"dependencies": ["postproc", { "config": "renderer.scale", "op": "<", "value": 1.0 }],
+				"config": "renderer.upscale.technique",
+				"list": [
+					{ "value": "fsr", "label": "FidelityFX Super Resolution 1.0", "tooltip": "Advanced upscale technique. For better results, use FSR with antialiasing enabled. Using it with the OpenGL backend may have some issues, consider using Vulkan backend instead." },
+					{ "value": "bilinear", "label": "Bilinear", "tooltip": "Bilinear upscale technique. Produces a slightly blurry picture depending on the scale." },
+					{ "value": "pixelated", "label": "Pixelated", "tooltip": "Simplest upscale technique. Used mostly for stylized effect." }
+				]
+			},
+			{
+				"type": "boolean",
+				"label": "Shadows",
+				"tooltip": "Enable shadows.",
+				"config": "shadows"
+			},
+			{
+				"type": "boolean",
+				"label": "Unit silhouettes",
+				"tooltip": "Show outlines of units behind structures.",
+				"config": "silhouettes"
+			},
+			{
+				"type": "boolean",
+				"label": "Particles",
+				"tooltip": "Enable particles.",
+				"config": "particles"
+			},
+			{
+				"type": "boolean",
+				"label": "VSync",
+				"tooltip": "Run vertical sync to fix screen tearing. REQUIRES GAME RESTART",
+				"config": "vsync"
+			},
+			{
+				"type": "slider",
+				"label": "FPS throttling in menus",
+				"tooltip": "To save CPU workload, throttle render frequency in all menus. Set to maximum to disable throttling.",
+				"config": "adaptivefps.menu",
+				"min": 20,
+				"max": 360
+			},
+			{
+				"type": "slider",
+				"label": "FPS throttling in games",
+				"tooltip": "To save CPU workload, throttle render frequency in running games. Set to maximum to disable throttling.",
+				"config": "adaptivefps.session",
+				"min": 20,
+				"max": 360
+			},
+			{
+				"type": "dropdownNumber",
+				"label": "GUI scale",
+				"timeout": 5000,
+				"tooltip": "GUI scale",
+				"config": "gui.scale",
+				"function": "SetGUIScale",
+				"list": [
+					{ "value": 0.75, "label": "75%" },
+					{ "value": 1.00, "label": "100%" },
+					{ "value": 1.25, "label": "125%" },
+					{ "value": 1.50, "label": "150%" },
+					{ "value": 1.75, "label": "175%" },
+					{ "value": 2.00, "label": "200%" },
+					{ "value": 2.25, "label": "225%" },
+					{ "value": 2.50, "label": "250%" }
+				]
+			},
+			{
+				"type": "number",
+				"label": "Mouse drag",
+				"tooltip": "Number of pixels the mouse can move before the action is considered a drag.",
+				"config": "gui.session.dragdelta",
+				"min": "1",
+				"max": "200"
+			},
+			{
+				"type": "boolean",
+				"label": "Mouse pan inverted",
+				"tooltip": "Invert middle-click drag pan direction.",
+				"config": "view.drag.inverted"
+			},
+			{
+				"type": "slider",
+				"label": "Mouse pan speed",
+				"tooltip": "Speed mouse pans the map when holding middle-click and dragging.",
+				"config": "view.drag.speed",
+				"min": 0.01,
+				"max": 0.6
+			},
+			{
+				"type": "boolean",
+				"label": "Mouse grab in fullscreen",
+				"tooltip": "Constrain mouse in the fullscreen mode to the window boundaries. It's used to avoid mouse going out of a display in case of multiple displays.",
+				"config": "window.mousegrabinfullscreen"
+			},
+			{
+				"type": "boolean",
+				"label": "Mouse grab in window mode",
+				"tooltip": "Constrain mouse in the window mode to the window boundaries.",
+				"config": "window.mousegrabinwindowmode"
+			}
+		]
+	},
+	{
+		"label": "Graphics (advanced)",
+		"tooltip": "Adjust advanced graphic options.",
+		"options":
+		[
+			{
+				"type": "dropdown",
+				"label": "Renderer backend",
+				"tooltip": "Choose the renderer's backend. It's recommended to use Vulkan if supported. REQUIRES GAME RESTART",
+				"config": "rendererbackend",
+				"list": [
+					{ "value": "gl", "label": "OpenGL", "tooltip": "Default OpenGL backend with GLSL. REQUIRES GAME RESTART" },
+					{ "value": "glarb", "label": "OpenGL ARB (Deprecated)", "tooltip": "Legacy OpenGL backend with ARB shaders. It's deprecated and it's going to be removed in future versions of the game. REQUIRES GAME RESTART" },
+					{ "value": "vulkan", "label": "Vulkan", "tooltip": "Modern API, requires up-to-date drivers. REQUIRES GAME RESTART" }
+				]
+			},
+			{
+				"type": "boolean",
+				"label": "Fog",
+				"tooltip": "Enable fog.",
+				"dependencies": [{ "config": "rendererbackend", "op": "!=", "value": "glarb" }],
+				"config": "fog"
+			},
+			{
+				"type": "boolean",
+				"label": "GPU skinning",
+				"tooltip": "Use GPU to update geometry for animated models. It reduces a CPU load during rendering especially on a modern hardware.",
+				"dependencies": [
+					{ "config": "rendererbackend", "op": "!=", "value": "glarb" }
+				],
+				"config": "gpuskinning"
+			},
+			{
+				"type": "boolean",
+				"label": "Post-processing",
+				"tooltip": "Use screen-space post-processing filters (HDR, Bloom, DOF, etc).",
+				"config": "postproc"
+			},
+			{
+				"type": "dropdown",
+				"label": "Antialiasing",
+				"tooltip": "Reduce aliasing effect on edges.",
+				"dependencies": ["postproc", { "config": "rendererbackend", "op": "!=", "value": "glarb" }],
+				"config": "antialiasing",
+				"list": [
+					{ "value": "disabled", "label": "Disabled", "tooltip": "Do not use antialiasing." },
+					{ "value": "fxaa", "label": "FXAA", "tooltip": "Fast, but simple antialiasing." },
+					{ "value": "msaa2", "label": "MSAA (2×)", "tooltip": "Slow, but high-quality antialiasing, uses two samples per pixel. Supported for GL3.3+." },
+					{ "value": "msaa4", "label": "MSAA (4×)", "tooltip": "Slow, but high-quality antialiasing, uses four samples per pixel. Supported for GL3.3+." },
+					{ "value": "msaa8", "label": "MSAA (8×)", "tooltip": "Slow, but high-quality antialiasing, uses eight samples per pixel. Supported for GL3.3+." },
+					{ "value": "msaa16", "label": "MSAA (16×)", "tooltip": "Slow, but high-quality antialiasing, uses sixteen samples per pixel. Supported for GL3.3+." }
+				]
+			},
+			{
+				"type": "dropdown",
+				"label": "Sharpening",
+				"tooltip": "Reduce blurry effects.",
+				"dependencies": ["postproc", { "config": "rendererbackend", "op": "!=", "value": "glarb" }],
+				"config": "sharpening",
+				"list": [
+					{ "value": "disabled", "label": "Disabled", "tooltip": "Do not use sharpening." },
+					{ "value": "cas", "label": "FidelityFX CAS", "tooltip": "Contrast adaptive sharpening, a fast, contrast based sharpening pass." }
+				]
+			},
+			{
+				"type": "slider",
+				"label": "Sharpness factor",
+				"tooltip": "The sharpness of the choosen pass.",
+				"dependencies": [
+					"postproc",
+					{ "config": "rendererbackend", "op": "!=", "value": "glarb" },
+					{ "config": "sharpening", "op": "!=", "value": "disabled" }
+				],
+				"config": "sharpness",
+				"min": 0,
+				"max": 1
+			},
+			{
+				"type": "dropdown",
+				"label": "Model quality",
+				"tooltip": "Model quality setting.",
+				"config": "max_actor_quality",
+				"list": [
+					{ "value": 100, "label": { "_string": "Low", "context": "Option for the meshes' level of detail." }, "tooltip": "Simpler models for better performance." },
+					{ "value": 150, "label": { "_string": "Medium", "context": "Option for the meshes' level of detail." }, "tooltip": "Average quality and average performance." },
+					{ "value": 200, "label": { "_string": "High", "context": "Option for the meshes' level of detail." }, "tooltip": "High quality models." }
+				]
+			},
+			{
+				"type": "dropdown",
+				"label": "Model appearance randomization",
+				"tooltip": "Randomize the appearance of entities. Disabling gives a small performance improvement.",
+				"config": "variant_diversity",
+				"list": [
+					{ "value": "none", "label": { "_string": "None", "context": "Option for the meshes' amount of variety." }, "tooltip": "Entities will all look the same." },
+					{ "value": "limited", "label": { "_string": "Limited", "context": "Option for the meshes' amount of variety." }, "tooltip": "Entities will be less diverse." },
+					{ "value": "full", "label": { "_string": "Normal", "context": "Option for the meshes' amount of variety." }, "tooltip": "Entities appearance is randomized normally." }
+				]
+			},
+			{
+				"type": "slider",
+				"label": "Shader effects",
+				"tooltip": "Number of shader effects. REQUIRES GAME RESTART",
+				"config": "materialmgr.quality",
+				"min": 0,
+				"max": 10
+			},
+			{
+				"type": "boolean",
+				"label": "Shadows",
+				"tooltip": "Enable shadows.",
+				"config": "shadows"
+			},
+			{
+				"type": "dropdown",
+				"label": "Quality",
+				"tooltip": "Shadow map resolution. High values can crash the game when using a graphics card with low memory!",
+				"dependencies": ["shadows"],
+				"config": "shadowquality",
+				"list": [
+					{ "value": -1, "label": { "_string": "Low", "context": "Option for the shadow quality." } },
+					{ "value": 0, "label": { "_string": "Medium", "context": "Option for the shadow quality." } },
+					{ "value": 1, "label": { "_string": "High", "context": "Option for the shadow quality." } },
+					{ "value": 2, "label": { "_string": "Very High", "context": "Option for the shadow quality." } }
+				]
+			},
+			{
+				"type": "boolean",
+				"label": "Filtering",
+				"tooltip": "Smooth shadows.",
+				"dependencies": ["shadows"],
+				"config": "shadowpcf"
+			},
+			{
+				"type": "boolean",
+				"label": "Cover whole map",
+				"tooltip": "When ON shadows cover the whole map and shadows cutoff distance is ignored. Useful for making screenshots of a whole map.",
+				"dependencies": ["shadows"],
+				"config": "shadowscovermap"
+			},
+			{
+				"type": "slider",
+				"label": "Cutoff distance",
+				"tooltip": "Hides shadows beyond a certain distance from a camera.",
+				"dependencies": ["shadows", { "config": "shadowscovermap", "value": "false" }],
+				"config": "shadowscutoffdistance",
+				"min": 100,
+				"max": 1500
+			},
+			{
+				"type": "boolean",
+				"label": "Water effects",
+				"tooltip": "When OFF, use the lowest settings possible to render water. This makes other settings irrelevant.",
+				"config": "watereffects"
+			},
+			{
+				"type": "boolean",
+				"label": "High-quality water effects",
+				"tooltip": "Use higher-quality effects for water, rendering coastal waves, shore foam, and ships trails.",
+				"dependencies": ["watereffects"],
+				"config": "waterfancyeffects"
+			},
+			{
+				"type": "boolean",
+				"label": "Water reflections",
+				"tooltip": "Allow water to reflect a mirror image.",
+				"dependencies": ["watereffects"],
+				"config": "waterreflection"
+			},
+			{
+				"type": "boolean",
+				"label": "Water refraction",
+				"tooltip": "Use a real water refraction map and not transparency.",
+				"dependencies": ["watereffects"],
+				"config": "waterrefraction"
+			},
+			{
+				"type": "boolean",
+				"label": "Real water depth",
+				"tooltip": "Use actual water depth in rendering calculations.",
+				"dependencies": ["watereffects", "waterrefraction"],
+				"config": "waterrealdepth"
+			},
+			{
+				"type": "dropdown",
+				"label": "Texture quality",
+				"tooltip": "Decrease texture quality making them blurrier but increases game performance.",
+				"config": "textures.quality",
+				"list": [
+					{ "value": 0, "label": { "_string": "Low", "context": "Option for the texture quality." }, "tooltip": "Low" },
+					{ "value": 1, "label": { "_string": "Medium", "context": "Option for the texture quality." }, "tooltip": "Medium" },
+					{ "value": 2, "label": { "_string": "High", "context": "Option for the texture quality." }, "tooltip": "High" }
+				]
+			},
+			{
+				"type": "dropdown",
+				"label": "Texture anisotropic filter",
+				"tooltip": "Makes textures look better, especially terrain. If the anisotropic filter value is unsupported it will be set to the max supported value.",
+				"config": "textures.maxanisotropy",
+				"list": [
+					{ "value": 1, "label": "1x", "tooltip": "Disabled" },
+					{ "value": 2, "label": "2x", "tooltip": "2x" },
+					{ "value": 4, "label": "4x", "tooltip": "4x" },
+					{ "value": 8, "label": "8x", "tooltip": "8x" },
+					{ "value": 16, "label": "16x", "tooltip": "16x" }
+				]
+			}
+		]
+	},
+	{
+		"label": "Sound",
+		"tooltip": "Make changes to the sound options.",
+		"options":
+		[
+			{
+				"type": "slider",
+				"label": "Master volume",
+				"tooltip": "Master audio gain.",
+				"config": "sound.mastergain",
+				"function": "SetMasterGain",
+				"min": 0,
+				"max": 2
+			},
+			{
+				"type": "slider",
+				"label": "Music volume",
+				"tooltip": "In game music gain.",
+				"config": "sound.musicgain",
+				"function": "SetMusicGain",
+				"min": 0,
+				"max": 2
+			},
+			{
+				"type": "slider",
+				"label": "Ambient volume",
+				"tooltip": "In game ambient sound gain.",
+				"config": "sound.ambientgain",
+				"function": "SetAmbientGain",
+				"min": 0,
+				"max": 2
+			},
+			{
+				"type": "slider",
+				"label": "Action volume",
+				"tooltip": "In game unit action sound gain.",
+				"config": "sound.actiongain",
+				"function": "SetActionGain",
+				"min": 0,
+				"max": 2
+			},
+			{
+				"type": "slider",
+				"label": "UI volume",
+				"tooltip": "UI sound gain.",
+				"config": "sound.uigain",
+				"function": "SetUIGain",
+				"min": 0,
+				"max": 2
+			},
+			{
+				"type": "boolean",
+				"label": "Nick notification",
+				"tooltip": "Receive audio notification when someone types your nick.",
+				"config": "sound.notify.nick"
+			},
+			{
+				"type": "boolean",
+				"label": "New player notification in game setup",
+				"tooltip": "Receive audio notification when a new client joins the game setup.",
+				"config": "sound.notify.gamesetup.join"
+			}
+		]
+	},
+	{
+		"label": "Game Setup",
+		"tooltip": "Change options relevant on the game setup page.",
+		"options":
+		[
+			{
+				"type": "boolean",
+				"label": "Enable game setting tips",
+				"tooltip": "Show tips when setting up a game.",
+				"config": "gui.gamesetup.enabletips"
+			},
+			{
+				"type": "boolean",
+				"label": "Enable settings panel slide",
+				"tooltip": "Slide the settings panel when opening, closing or resizing.",
+				"config": "gui.gamesetup.settingsslide"
+			},
+			{
+				"type": "boolean",
+				"label": "Persist match settings",
+				"tooltip": "Save and restore match settings for quick reuse when hosting another game.",
+				"config": "persistmatchsettings"
+			},
+			{
+				"type": "dropdown",
+				"label": "Default AI difficulty",
+				"tooltip": "Default difficulty of the AI.",
+				"config": "gui.gamesetup.aidifficulty",
+				"list": [
+					{ "value": 0, "label": { "_string": "Sandbox", "context": "Option for the AI difficulty." }},
+					{ "value": 1, "label": { "_string": "Very Easy", "context": "Option for the AI difficulty." }},
+					{ "value": 2, "label": { "_string": "Easy", "context": "Option for the AI difficulty." }},
+					{ "value": 3, "label": { "_string": "Medium", "context": "Option for the AI difficulty." }},
+					{ "value": 4, "label": { "_string": "Hard", "context": "Option for the AI difficulty." }},
+					{ "value": 5, "label": { "_string": "Very Hard", "context": "Option for the AI difficulty." }}
+				]
+			},
+			{
+				"type": "dropdown",
+				"label": "Default AI behavior",
+				"tooltip": "Default behavior of the AI.",
+				"config": "gui.gamesetup.aibehavior",
+				"list": [
+					{ "value": "random", "label": "Random" },
+					{ "value": "balanced", "label": "Balanced" },
+					{ "value": "aggressive", "label": "Aggressive" },
+					{ "value": "defensive", "label": "Defensive" }
+				]
+			},
+			{
+				"type": "dropdown",
+				"label": "Assign players",
+				"tooltip": "Automatically assign joining clients to free player slots during the match setup.",
+				"config": "gui.gamesetup.assignplayers",
+				"list": [
+					{
+						"value": "everyone",
+						"label": "Everyone",
+						"tooltip": "Players joining the match will be assigned if there is a free slot."
+					},
+					{
+						"value": "buddies",
+						"label": "Buddies",
+						"tooltip": "Players joining the match will only be assigned if they are a buddy of the host and if there is a free slot."
+					},
+					{
+						"value": "disabled",
+						"label": "Disabled",
+						"tooltip": "Players only receive a slot when the host assigns them explicitly."
+					}
+				]
+			}
+		]
+	},
+	{
+		"label": "Networking / Lobby",
+		"tooltip": "Change multiplayer options.",
+		"options":
+		[
+			{
+				"type": "boolean",
+				"label": "TLS encryption",
+				"tooltip": "Protect login and data exchanged with the lobby server using TLS encryption.",
+				"config": "lobby.tls"
+			},
+			{
+				"type": "number",
+				"label": "Chat backlog",
+				"tooltip": "Number of backlogged messages to load when joining the lobby.",
+				"config": "lobby.history",
+				"min": "0"
+			},
+			{
+				"type": "boolean",
+				"label": "Game rating column",
+				"tooltip": "Show the average rating of the participating players in a column of the gamelist.",
+				"config": "lobby.columns.gamerating"
+			},
+			{
+				"type": "boolean",
+				"label": "Network warnings",
+				"tooltip": "Show which player has a bad connection in multiplayer games.",
+				"config": "overlay.netwarnings"
+			},
+			{
+				"type": "dropdown",
+				"label": "Late observer joins",
+				"tooltip": "Allow everybody or buddies only to join the game as observer after it started.",
+				"config": "network.lateobservers",
+				"list": [
+					{ "value": "everyone", "label": "Everyone" },
+					{ "value": "buddies", "label": "Buddies" },
+					{ "value": "disabled", "label": "Disabled" }
+				]
+			},
+			{
+				"type": "number",
+				"label": "Observer limit",
+				"tooltip": "Prevent further observers from joining if the limit is reached.",
+				"config": "network.observerlimit",
+				"min": 0,
+				"max": 32
+			},
+			{
+				"type": "number",
+				"label": "Max lag for observers",
+				"tooltip": "When hosting, pause the game if observers are lagging more than this many turns. If set to -1, observers are ignored.",
+				"config": "network.observermaxlag",
+				"min": -1,
+				"max": 10000
+			},
+			{
+				"type": "boolean",
+				"label": "(Observer) Speed up when lagging.",
+				"tooltip": "When observing a game, automatically speed up if you start lagging, to catch up with the live match.",
+				"config": "network.autocatchup"
+			}
+		]
+	},
+	{
+		"label": "Chat & Notifications",
+		"tooltip": "Configure the in-game chat.",
+		"options": [
+			{
+				"type": "boolean",
+				"label": "Chat timestamp",
+				"tooltip": "Display the time when a chat message was posted.",
+				"config": "chat.timestamp"
+			},
+			{
+				"type": "boolean",
+				"label": "Chat notification attack",
+				"tooltip": "Show a chat notification if you are attacked by another player.",
+				"config": "gui.session.notifications.attack"
+			},
+			{
+				"type": "boolean",
+				"label": "Chat notification tribute",
+				"tooltip": "Show a chat notification if an ally tributes resources to another team member if teams are locked, and all tributes in observer mode.",
+				"config": "gui.session.notifications.tribute"
+			},
+			{
+				"type": "boolean",
+				"label": "Chat notification barter",
+				"tooltip": "Show a chat notification to observers when a player bartered resources.",
+				"config": "gui.session.notifications.barter"
+			},
+			{
+				"type": "dropdown",
+				"label": "Chat notification flare",
+				"tooltip": "Show a chat notification when a player sends a flare.",
+				"config": "gui.session.notifications.flare",
+				"list": [
+					{ "value": "never", "label": "Never", "tooltip": "Disable flare chat notifications."},
+					{ "value": "observer", "label": "Only as observer", "tooltip": "Only show flare chat notifications when you are observer."},
+					{ "value": "always", "label": "Always", "tooltip": "Always show flare chat notifications – as player and as observer."}
+				]
+			},
+			{
+				"type": "dropdown",
+				"label": "Chat notification phase",
+				"tooltip": "Show a chat notification if you or an ally have started, aborted or completed a new phase, and phases of all players in observer mode.",
+				"config": "gui.session.notifications.phase",
+				"list": [
+					{ "value": "none", "label": "Disable" },
+					{ "value": "completed", "label": "Completed" },
+					{ "value": "all", "label": "All displayed" }
+				]
+			}
+		]
+	},
+	{
+		"label": "Display",
+		"tooltip": "Customise the in-game display.",
+		"options":
+		[
+			{
+				"type": "boolean",
+				"label": "Detailed tooltips",
+				"tooltip": "Show detailed tooltips for trainable units in structures.",
+				"config": "showdetailedtooltips"
+			},
+			{
+				"type": "dropdown",
+				"label": "Naming of entities",
+				"tooltip": "How to show entity names.",
+				"config": "gui.session.howtoshownames",
+				"list": [
+					{
+						"value": 0,
+						"label": "Specific names first",
+						"tooltip": "Display specific names before generic names."
+					},
+					{
+						"value": 1,
+						"label": "Generic names first",
+						"tooltip": "Display generic names before specific names."
+					},
+					{
+						"value": 2,
+						"label": "Only specific names",
+						"tooltip": "Display only specific names for entities."
+					},
+					{
+						"value": 3,
+						"label": "Only generic names",
+						"tooltip": "Display only generic names for entities."
+					}
+				]
+			},
+			{
+				"type": "dropdown",
+				"label": "Sort resources and population tooltip",
+				"tooltip": "Dynamically sort players in the resources and population tooltip by value.",
+				"config": "gui.session.respoptooltipsort",
+				"list": [
+					{ "value": 0, "label": "Unordered" },
+					{ "value": -1, "label": "Ascending" },
+					{ "value": 1, "label": "Descending" }
+				]
+			},
+			{
+				"type": "boolean",
+				"label": "FPS overlay",
+				"tooltip": "Show frames per second in top right corner.",
+				"config": "overlay.fps"
+			},
+			{
+				"type": "boolean",
+				"label": "Real time overlay",
+				"tooltip": "Show current system time in top right corner.",
+				"config": "overlay.realtime"
+			},
+			{
+				"type": "boolean",
+				"label": "Game time overlay",
+				"tooltip": "Show current simulation time in top right corner.",
+				"config": "gui.session.timeelapsedcounter"
+			},
+			{
+				"type": "boolean",
+				"label": "Ceasefire time overlay",
+				"tooltip": "Always show the remaining ceasefire time.",
+				"config": "gui.session.ceasefirecounter"
+			},
+			{
+				"type": "slider",
+				"label": "Flare display duration",
+				"tooltip": "How long the flare markers on the minimap are displayed in seconds.",
+				"config": "gui.session.flarelifetime",
+				"min": 0,
+				"max": 60
+			},
+			{
+				"type": "boolean",
+				"label": "Minimap icons",
+				"tooltip": "Show special icons for some entities on the minimap.",
+				"config": "gui.session.minimap.icons.enabled"
+			},
+			{
+				"type": "boolean",
+				"label": "Rank icon above status bar",
+				"tooltip": "Show rank icons above status bars.",
+				"config": "gui.session.rankabovestatusbar"
+			},
+			{
+				"type": "boolean",
+				"label": "Experience status bar",
+				"tooltip": "Show an experience status bar above each selected unit.",
+				"config": "gui.session.experiencestatusbar"
+			},
+			{
+				"type": "boolean",
+				"label": "Attack range visualization",
+				"tooltip": "Display the attack range of selected defensive structures. (It can also be toggled with the hotkey during a game).",
+				"config": "gui.session.attackrange"
+			},
+			{
+				"type": "boolean",
+				"label": "Aura range visualization",
+				"tooltip": "Display the range of auras of selected units and structures. (It can also be toggled with the hotkey during a game).",
+				"config": "gui.session.aurasrange"
+			},
+			{
+				"type": "boolean",
+				"label": "Heal range visualization",
+				"tooltip": "Display the healing range of selected units. (It can also be toggled with the hotkey during a game).",
+				"config": "gui.session.healrange"
+			},
+			{
+				"type": "color",
+				"label": "Diplomacy colors: self",
+				"tooltip": "Color of your units when diplomacy colors are enabled.",
+				"config": "gui.session.diplomacycolors.self"
+			},
+			{
+				"type": "color",
+				"label": "Diplomacy colors: ally",
+				"tooltip": "Color of allies when diplomacy colors are enabled.",
+				"config": "gui.session.diplomacycolors.ally"
+			},
+			{
+				"type": "color",
+				"label": "Diplomacy colors: neutral",
+				"tooltip": "Color of neutral players when diplomacy colors are enabled.",
+				"config": "gui.session.diplomacycolors.neutral"
+			},
+			{
+				"type": "color",
+				"label": "Diplomacy colors: enemy",
+				"tooltip": "Color of enemies when diplomacy colors are enabled.",
+				"config": "gui.session.diplomacycolors.enemy"
+			}
+		]
+	},
+	{
+		"label": "Autociv Stats Panel",
+		"tooltip": "Content to show on the stats panel of autociv",
+		"options":
+		[
+			{
+				"type": "boolean",
+				"label": "Resources counts",
+				"tooltip": "Show the total number of resources of each type?",
+				"config": "autociv.stats.resources"
+			},
+			{
+				"type": "boolean",
+				"label": "Show allies stats",
+				"tooltip": "Show the counters for all of your allies?",
+				"config": "autociv.stats.alliesview"
+			},
+			{
+				"type": "boolean",
+				"label": "Military unit compositions",
+				"tooltip": "Show the number of melee, ranged and cavalry units that you have?",
+				"config": "autociv.stats.militarycomposition"
+			},
+			{
+				"type": "boolean",
+				"label": "Kill-Death performance",
+				"tooltip": "Show your kill count, loss and kill death ratio?",
+				"config": "autociv.stats.kdratio"
+			},
+			{
+				"type": "number",
+				"label": "Counter update frequency",
+				"tooltip": "The update frequency of the autociv stats panel. Higher values mean faster update but more CPU consumption. ",
+				"config": "autociv.stats.pollingrate"
+			}
+		]
+	},
+	{
+		"label": "Gameplay",
+		"tooltip": "Change options affecting the gameplay.",
+		"options":
+		[
+			{
+				"type": "slider",
+				"label": "Wounded unit health",
+				"tooltip": "The wounded unit hotkey considers the selected units as wounded if their health percentage falls below this number.",
+				"config": "gui.session.woundedunithotkeythreshold",
+				"min": 0,
+				"max": 100
+			},
+			{
+				"type": "number",
+				"label": "Batch training size",
+				"tooltip": "Number of units trained per batch by default.",
+				"config": "gui.session.batchtrainingsize",
+				"min": 1,
+				"max": 20
+			},
+			{
+				"type": "slider",
+				"label": "Scroll batch increment ratio",
+				"tooltip": "Number of times you have to scroll to increase/decrease the batchsize by 1.",
+				"config": "gui.session.scrollbatchratio",
+				"min": 0.1,
+				"max": 30
+			},
+
+			{
+				"type": "dropdown",
+				"label": "Snap to edges",
+				"tooltip": "This option allows to align new structures with nearby structures.",
+				"config": "gui.session.snaptoedges",
+				"list": [
+					{
+						"value": "disabled",
+						"label": "Hotkey to enable snapping",
+						"tooltip": "New structures are aligned with nearby structures while pressing the hotkey."
+					},
+					{
+						"value": "enabled",
+						"label": "Hotkey to disable snapping",
+						"tooltip": "New structures are aligned with nearby structures unless the hotkey is pressed."
+					}
+				]
+			},
+			{
+				"type": "dropdown",
+				"label": "Control group membership",
+				"tooltip": "Decide whether units can be part of multiple control groups.",
+				"config": "gui.session.disjointcontrolgroups",
+				"list": [
+					{
+						"value": "true",
+						"label": "Single",
+						"tooltip": "When adding a Unit or Structure to a control group, they are removed from other control groups. Use this choice if you want control groups to refer to distinct armies."
+					},
+					{
+						"value": "false",
+						"label": "Multiple",
+						"tooltip": "Units and Structures can be part of multiple control groups. This is useful to keep control groups for distinct armies and a control group for the entire army simultaneously."
+					}
+				]
+			},
+			{
+				"type": "dropdown",
+				"label": "Formation control",
+				"tooltip": "Decide whether formations are enabled for all orders or only 'Walk' and 'Patrol'.",
+				"config": "gui.session.formationwalkonly",
+				"list": [
+					{
+						"value": "true",
+						"label": "Walk/Patrol Only",
+						"tooltip": "Other orders will disband existing formations."
+					},
+					{
+						"value": "false",
+						"label": "No override",
+						"tooltip": "Units in formations stay in formations."
+					}
+				]
+			},
+			{
+				"type": "boolean",
+				"label": "Battalion-style formations",
+				"tooltip": "Whether formations are selected as a whole.",
+				"config": "gui.session.selectformationasone"
+			}
+		]
+	}
+]

--- a/gui/session/objectives/autociv_statsOverlay.js
+++ b/gui/session/objectives/autociv_statsOverlay.js
@@ -19,12 +19,14 @@ AutocivControls.StatsOverlay = class
     }
     stats = {
         " P": state => state.phase,
-        " Pop": state => state.popCount,
+        " Pop": state => state.classCounts_Support + state.classCounts_Infantry + state.classCounts_Cavalry,
         " Sup": state => state.classCounts_Support,
         " Inf": state => state.classCounts_Infantry,
         " Cav": state => state.classCounts_Cavalry,
         " Sig": state => state.classCounts_Siege,
         " Chp": state => state.classCounts_Champion,
+        " Mel": state => state.classCounts_Melee,
+        " Ran": state => state.classCounts_Ranged,
         "   Food": state => Math.round(state.resourceCounts["food"]),
         "   Wood": state => Math.round(state.resourceCounts["wood"]),
         "  Stone": state => Math.round(state.resourceCounts["stone"]),
@@ -59,9 +61,7 @@ AutocivControls.StatsOverlay = class
         this.autociv_brightnessThreshold = Engine.ConfigDB_GetValue("user", this.configKey_brightnessThreshold)
         this.autociv_symbolizeRating = Engine.ConfigDB_GetValue("user", this.configKey_symbolizeRating) == "true"
 
-        let headers_to_show = ["P", " Pop"];
-
-        let contentlist = { ...this.preStatsDefault, ...this.preStatsTeam, ...headers_to_show};
+        let contentlist = { ...this.preStatsDefault, ...this.preStatsTeam, ...this.stats};
 
         for (let name in contentlist)
             this.widths[name] = name.length
@@ -225,7 +225,7 @@ AutocivControls.StatsOverlay = class
 
     calcWidth(rowLength)
     {
-        return Engine.GetTextWidth(this.textFont, " ")*1.2* rowLength + this.autociv_statsOverlay.buffer_zone * 2
+        return Engine.GetTextWidth(this.textFont, " ")* 1.01* rowLength + this.autociv_statsOverlay.buffer_zone * 2
     }
 
     calcHeight(rowQuantity)
@@ -257,24 +257,15 @@ AutocivControls.StatsOverlay = class
         if (!playerStates)
             return
 
-        let headers_to_show = [" P", " Pop"];
-
         let header = Object.keys(this.widths).
-            map(row => this.leftPadTrunc(row, this.widths[row])).
-            join(" ")
+        map(row => this.leftPadTrunc(row, this.widths[row])).
+        join("")
         const rowLength = header.length
-        header = setStringTags(header, { "color": "210 210 210" })
+        header = setStringTags(header, { "color": "250 250 250" })
         header += "\n"
 
         const values = {}
-
-        // //here we add selection statements to decide which values to show
-        // let headers_to_show = Object.keys(this.stats) //by default, everything in stats should be shown to make the panel meaningful
-        //
-        // let kdheaders = Object.keys(this.kdstats) //option to show kd
-
-
-        for (let stat of headers_to_show)
+        for (let stat of Object.keys(this.stats))
         {
             let list = playerStates.map(this.stats[stat])
             values[stat] = {
@@ -283,7 +274,6 @@ AutocivControls.StatsOverlay = class
                 "max": this.maxIndex(list),
             }
         }
-
         const entries = playerStates.map((state, index) =>
         {
             const preStatsDefault = Object.keys(this.preStatsDefault).
@@ -317,12 +307,6 @@ AutocivControls.StatsOverlay = class
             //     //     default: return text
             //     // }
             // }).join("")
-
-            print("\n");
-            print(stats);
-            print(" | ");
-            //print(kdstats);
-            print("\n");
 
             if (state.state == "defeated")
                 return setStringTags(preStatsDefault + preStatsTeam + stats, { "color": "255 255 255 128" })

--- a/simulation/components/GuiInterface~autociv.js
+++ b/simulation/components/GuiInterface~autociv.js
@@ -222,6 +222,8 @@ GuiInterface.prototype.autociv_GetStatsOverlay = function ()
             "classCounts_Cavalry": classCounts?.Cavalry ?? 0,
             "classCounts_Siege": (classCounts?.Siege ?? 0),
             "classCounts_Champion": (classCounts?.Champion ?? 0),
+            "classCounts_Melee": (classCounts?.Melee ?? 0),
+            "classCounts_Ranged": (classCounts?.Ranged ?? 0),
             "enemyUnitsKilledTotal": cmpPlayerStatisticsTracker?.enemyUnitsKilled.Unit ?? 0
         });
     }


### PR DESCRIPTION
Additional counters for:
Loss
KD ratio
Melee counter
Ranged units counter

Population counter changed from predicted pop to actual pop. By default, the 0ad pop counter shows the the sum of units being trained and the already trained. I have changed the autociv counter to showing only the already trained units count, which is a previously missing yet a very important piece of information. 