### PR TITLE
Options fixes

### DIFF
--- a/gui/options/options.json
+++ b/gui/options/options.json
@@ -786,43 +786,6 @@
 		]
 	},
 	{
-		"label": "Autociv Stats Panel",
-		"tooltip": "Content to show on the stats panel of autociv",
-		"options":
-		[
-			{
-				"type": "boolean",
-				"label": "Resources counts",
-				"tooltip": "Show the total number of resources of each type?",
-				"config": "autociv.stats.resources"
-			},
-			{
-				"type": "boolean",
-				"label": "Show allies stats",
-				"tooltip": "Show the counters for all of your allies?",
-				"config": "autociv.stats.alliesview"
-			},
-			{
-				"type": "boolean",
-				"label": "Military unit compositions",
-				"tooltip": "Show the number of melee, ranged and cavalry units that you have?",
-				"config": "autociv.stats.militarycomposition"
-			},
-			{
-				"type": "boolean",
-				"label": "Kill-Death performance",
-				"tooltip": "Show your kill count, loss and kill death ratio?",
-				"config": "autociv.stats.kdratio"
-			},
-			{
-				"type": "number",
-				"label": "Counter update frequency",
-				"tooltip": "The update frequency of the autociv stats panel. Higher values mean faster update but more CPU consumption. ",
-				"config": "autociv.stats.pollingrate"
-			}
-		]
-	},
-	{
 		"label": "Gameplay",
 		"tooltip": "Change options affecting the gameplay.",
 		"options":

--- a/gui/session/objectives/autociv_statsOverlay.js
+++ b/gui/session/objectives/autociv_statsOverlay.js
@@ -17,7 +17,7 @@ AutocivControls.StatsOverlay = class
     preStatsTeam = {
         "T ": state => state.team != -1 ? `${state.team + 1}` : "", // Team number
     }
-    stats = {
+    stats = Engine.ConfigDB_GetValue("user", "autociv.stats.resources") == "true" ? {
         " P": state => state.phase,
         " Pop": state => state.classCounts_Support + state.classCounts_Infantry + state.classCounts_Cavalry,
         " Sup": state => state.classCounts_Support,
@@ -35,8 +35,16 @@ AutocivControls.StatsOverlay = class
         " Kill": state => state.enemyUnitsKilledTotal ?? 0,
         " Loss": state => state.unitsLost ?? 0,
         "  KDr": state => state.enemyUnitsKilledTotal/ state.unitsLost ?? 0
+    } : {
+        " P": state => state.phase,
+        " Pop": state => state.classCounts_Support + state.classCounts_Infantry + state.classCounts_Cavalry,
+        " Fem": state => state.classCounts_Support,
+        " Inf": state => state.classCounts_Infantry,
+        " Cav": state => state.classCounts_Cavalry,
+        " Kill": state => state.enemyUnitsKilledTotal ?? 0,
+        "  KDr": state => state.enemyUnitsKilledTotal/ state.unitsLost ?? 0
 
-    }
+    };
 
     kdstats = {
         " Kill": state => state.enemyUnitsKilledTotal ?? 0,
@@ -49,7 +57,7 @@ AutocivControls.StatsOverlay = class
     preStatsSeenBefore = {}
     stateStrengthsCached = {}
     widths = {} // Will be filled on the constructor
-    tickPeriod  = Engine.ConfigDB_GetValue("user", "autociv.stats.pollingrate") ?? 10
+    tickPeriod  = 0
     textFont = "mono-stroke-10"
     configKey_visible = "autociv.session.statsOverlay.visible"
     configKey_brightnessThreshold = "autociv.session.statsOverlay.brightnessThreshold"
@@ -71,10 +79,9 @@ AutocivControls.StatsOverlay = class
         registerPlayersFinishedHandler(this.updatePlayerLists.bind(this));
         this.update()
         registerConfigChangeHandler(this.onConfigChanges.bind(this))
-        print(this.showResources);
-        print(this.showAllies);
-        print(this.showKD);
-        print(this.tickPeriod);
+
+        print("Autociv update frequency: ");
+        print(this.tickPeriod.toString());
     }
 
     onConfigChanges(changes)
@@ -248,10 +255,23 @@ AutocivControls.StatsOverlay = class
                 return false
 
             state.playerNumber = index
-            if (g_IsObserver || !g_Players[g_ViewedPlayer] || index == g_ViewedPlayer)
+
+            if (index == g_ViewedPlayer) {
                 return true
-            if (!playerStates[g_ViewedPlayer].hasSharedLos || !g_Players[g_ViewedPlayer].isMutualAlly[index])
+            }
+
+            if (this.showAllies) {
+
+                if (g_IsObserver || !g_Players[g_ViewedPlayer] || index == g_ViewedPlayer)
+                    return true
+                if (!playerStates[g_ViewedPlayer].hasSharedLos || !g_Players[g_ViewedPlayer].isMutualAlly[index])
+                    return false
+
+            }
+            else {
                 return false
+            }
+
             return true
         })
 

--- a/moddata/autociv_options.json
+++ b/moddata/autociv_options.json
@@ -36,6 +36,12 @@
 			},
 			{
 				"type": "boolean",
+				"label": "[color=\"220 185 70\"]Graphics:[/color] Enable eyecandy",
+				"tooltip": "This option allows you to enable and disable eyecandy features on the map that are not actively taking part in the game. For example, there are purely decorational bushes and flowers that you cannot gather resources from. By setting this option to false, you can hide these decorational bushes to avoid confusion and de-clutter the map. Disabling this option also offers a slight performance improvement",
+				"config": "renderactors"
+			},
+			{
+				"type": "boolean",
 				"label": "[color=\"220 185 70\"]Game setup:[/color] countdown enable",
 				"tooltip": "Automatically enable countdown when hosting",
 				"config": "autociv.gamesetup.countdown.enabled"
@@ -56,14 +62,29 @@
 			},
 			{
 				"type": "boolean",
-				"label": "[color=\"220 185 70\"]Game:[/color] Symbolize the rating",
+				"label": "[color=\"220 185 70\"]StatsOverlay:[/color] Symbolize the rating",
 				"tooltip": "Transform the user rating or the AI difficulty level into an icon to indicate their strength.\n\n[color=\"220 185 70\"]\u25B2[/color]  Top\n[color=\"220 185 70\"]\u25C6[/color]  Good\n[color=\"220 185 70\"]\u25A0[/color]  Decent\n[color=\"220 185 70\"]\u25AC[/color]  Beginner\n[color=\"220 185 70\"]\u25A1[/color]  Noob\n",
 				"config": "autociv.session.statsOverlay.symbolizeRating",
 				"dependencies": ["autociv.session.statsOverlay.visible"]
 			},
 			{
+				"type": "boolean",
+				"label": "[color=\"220 185 70\"]StatsOverlay:[/color] Detailed Stats",
+				"tooltip": "Show the detailed statistics for you? Includes more unit types, techs to evaluate your current strength.",
+				"config": "autociv.stats.resources",
+				"dependencies": ["autociv.session.statsOverlay.visible"]
+			},
+			{
+				"type": "boolean",
+				"label": "[color=\"220 185 70\"]StatsOverlay:[/color] Show allies stats",
+				"tooltip": "Show the counters for all of your allies?",
+				"config": "autociv.stats.alliesview",
+				"dependencies": ["autociv.session.statsOverlay.visible"]
+			},
+
+			{
 				"type": "slider",
-				"label": "[color=\"220 185 70\"]Game:[/color] Brightness of player names",
+				"label": "[color=\"220 185 70\"]StatsOverlay:[/color] Brightness of player names",
 				"tooltip": "Adjust the brightness intensity for the player names.",
 				"config": "autociv.session.statsOverlay.brightnessThreshold",
 				"dependencies": ["autociv.session.statsOverlay.visible"],


### PR DESCRIPTION
- Removed redundant options: show KD stats, military stats and update frequency. Instead, we let the user choose between detailed counters and minimal counters. 
- Migrated the stats panel configurations into the same page as autociv
- Cleaned up the code format and unessential debugging prints. 